### PR TITLE
update: add Per-app language settings

### DIFF
--- a/android/src/main/java/com/levelasquez/androidopensettings/AndroidOpenSettings.java
+++ b/android/src/main/java/com/levelasquez/androidopensettings/AndroidOpenSettings.java
@@ -135,6 +135,18 @@ public class AndroidOpenSettings extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void appLocaleSettings() {
+        Intent intent = new Intent(Settings.ACTION_APP_LOCALE_SETTINGS);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        intent.setData(Uri.parse("package:" + reactContext.getPackageName()));
+
+        if (intent.resolveActivity(reactContext.getPackageManager()) != null) {
+            reactContext.startActivity(intent);    
+        }
+    }
+
+    @ReactMethod
     public void inputMethodSettings() {
         Intent intent = new Intent(Settings.ACTION_INPUT_METHOD_SETTINGS);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module "react-native-android-open-settings" {
   const bluetoothSettings: () => void;
   const dateSettings: () => void;
   const localeSettings: () => void;
+  const appLocaleSettings: () => void;
   const inputMethodSettings: () => void;
   const displaySettings: () => void;
   const securitySettings: () => void;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ const dateSettings = () => RNAndroidOpenSettings.dateSettings()
 
 const localeSettings = () => RNAndroidOpenSettings.localeSettings()
 
+const appLocaleSettings = () => RNAndroidOpenSettings.appLocaleSettings()
+
 const inputMethodSettings = () => RNAndroidOpenSettings.inputMethodSettings()
 
 const displaySettings = () => RNAndroidOpenSettings.displaySettings()
@@ -54,6 +56,7 @@ module.exports = {
   bluetoothSettings,
   dateSettings,
   localeSettings,
+  appLocaleSettings,
   inputMethodSettings,
   displaySettings,
   securitySettings,


### PR DESCRIPTION
Support Androoid Per-app Language settings open

add method ```appLocaleSettings```

https://medium.com/r/?url=https%3A%2F%2Fdeveloper.android.com%2Freference%2Fandroid%2Fprovider%2FSettings%23ACTION_APP_LOCALE_SETTINGS